### PR TITLE
修复分账回退等接口通用返回未解析到err的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@
 [![go.dev doc](https://img.shields.io/badge/go.dev-doc-green)](https://pkg.go.dev/github.com/wleven/wxpay)
 [![GitHub license](https://img.shields.io/github/license/wleven/wxpay)](https://github.com/wleven/wxpay/blob/master/LICENSE)
 
-- [安装包](#安装包)
-- [查看文档](#查看文档)
-- [V2 版本下单接口](#V2版本下单接口)
-- [V2 版本分账接口](#V2版本分账接口)
-- [V2 版本企业付款到零钱](#V2版本企业付款到零钱)
-- [V3 版本支付即服务接口](#V3版本支付即服务接口)
+- [微信支付 SDK](#微信支付-sdk)
+  - [安装包](#安装包)
+  - [查看文档](#查看文档)
+  - [V2 版本下单接口](#v2-版本下单接口)
+  - [V2 版本分账接口](#v2-版本分账接口)
+  - [V2 版本企业付款到零钱](#v2-版本企业付款到零钱)
+  - [V3 版本支付即服务接口](#v3-版本支付即服务接口)
 
 ## 安装包
 
@@ -53,6 +54,12 @@ if data, err := wxpay.V2.UnifiedOrder(V2.UnifiedOrder{/* 传入参数 */}); err 
 }
 // 小程序支付
 if data, err := wxpay.V2.WxAppPay(V2.UnifiedOrder{/* 传入参数 */}); err == nil {
+}
+// APP支付
+if data, err := wxpay.V2.WxAppAppPay(V2.UnifiedOrder{/* 传入参数 */}); err == nil {
+}
+// H5支付
+if data, err := wxpay.V2.WxH5Pay(V2.UnifiedOrder{/* 传入参数 */}); err == nil {
 }
 // 付款码支付
 if data, err := wxpay.V2.Micropay(V2.Micropay{/* 传入参数 */}); err == nil {

--- a/src/V2/entity.go
+++ b/src/V2/entity.go
@@ -102,12 +102,16 @@ type PublicResponse struct {
 	ResultMsg  string `xml:"result_msg,omitempty" json:"result_msg,omitempty"`     // 对于业务执行的详细描述
 	ErrCode    string `xml:"err_code,omitempty" json:"err_code,omitempty"`         // 当result_code为FAIL时返回错误代码
 	ErrCodeDes string `xml:"err_code_des,omitempty" json:"err_code_des,omitempty"` // 当result_code为FAIL时返回错误描述
+	ErrorMsg   string `xml:"error_msg,omitempty" json:"error_msg,omitempty"`       // 当result_code为FAIL时返回错误描述
 }
 
 // ResultCheck 检查是否返回成功
 func (m PublicResponse) ResultCheck() error {
 	if m.ReturnCode == "FAIL" {
-		return errors.New(m.ReturnMsg)
+		if m.ResultMsg != "" {
+			return errors.New(m.ReturnMsg)
+		}
+		return errors.New(m.ErrorMsg)
 	} else if m.ResultCode == "FAIL" {
 		return errors.New(m.ErrCodeDes)
 	}


### PR DESCRIPTION
分账回退：
```
<xml>
<return_code><![CDATA[FAIL]]></return_code>
<error_code><![CDATA[PARAM_ERROR]]></error_code>
<error_msg><![CDATA[分账并没有分给对应的回退方]]></error_msg>
</xml>
```
此时return_code为FAIL，但没有return_msg而是error_msg
