### PR TITLE
goroutine leak

### DIFF
--- a/src/V2/pay.go
+++ b/src/V2/pay.go
@@ -40,6 +40,7 @@ func (c WxPay) request(url string, body io.Reader, cert bool) (map[string]string
 		pool.AppendCertsFromPEM(rootCa)
 
 		client = http.Client{Transport: &http.Transport{
+			DisableKeepAlives: true,
 			TLSClientConfig: &tls.Config{
 				RootCAs:      pool,
 				Certificates: []tls.Certificate{certs},


### PR DESCRIPTION
为了省时间选择了wxpay,但实战项目中，内存溢出，查找原因。这里keep alive会导致goroutine leak. 
解决：Transport 添加 DisableKeepAlives: true
more: https://github.com/distribution/distribution/issues/473#issuecomment-97691676