### PR TITLE
修复服务商小程序支付

### DIFF
--- a/src/V2/pay.go
+++ b/src/V2/pay.go
@@ -136,7 +136,6 @@ func (c WxPay) WxAppPay(params UnifiedOrder) (map[string]interface{}, error) {
 		} else {
 			result["appId"] = m["appId"]
 		}
-		result["appId"] = m["appid"]
 		result["nonceStr"] = m["nonce_str"]
 		result["package"] = "prepay_id=" + m["prepay_id"]
 		result["timeStamp"] = strconv.FormatInt(time.Now().Unix(), 10)

--- a/src/V2/pay.go
+++ b/src/V2/pay.go
@@ -131,6 +131,11 @@ func (c WxPay) WxAppPay(params UnifiedOrder) (map[string]interface{}, error) {
 	m, err := c.UnifiedOrder(params)
 	if err == nil {
 		result := make(map[string]interface{})
+		if c.config.SubAppID != "" {
+			result["appId"] = m["sub_appid"]
+		} else {
+			result["appId"] = m["appId"]
+		}
 		result["appId"] = m["appid"]
 		result["nonceStr"] = m["nonce_str"]
 		result["package"] = "prepay_id=" + m["prepay_id"]


### PR DESCRIPTION
商户号小程序支付错误,这里需要的appid是sub_appid,并且修改后成功支付,如果appid和sub_appld相同则不会出问题